### PR TITLE
fixed "broken" target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ DATA_ARCHIVE = ndata.zip
 if HAVE_UTILS
 MKSPR      = utils/mkspr/mkspr$(EXEEXT)
 endif
-NOXIMPERII	     = "noximperii"$(EXEEXT)
+NOXIMPERII	     = noximperii$(EXEEXT)
 
 EXTRA_DIST = LICENSE extras noximperii.desktop noximperii.appdata.xml
 CLEANFILES = $(DATA_ARCHIVE) $(NOXIMPERII)


### PR DESCRIPTION
now make does not provide error message: 
ln: failed to create symbolic link 'noximperii': File exists